### PR TITLE
Fixes sidekiq to run on its own instance

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Roz
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.time_zone = "Africa/Johannesburg"
+    config.active_job.queue_adapter = :sidekiq
     config.generators do |g|
       g.orm                :active_record
       g.template_engine    :slim


### PR DESCRIPTION
**Why**
Sidekiq was running on the rails server instead of its own instance

**How**
  - Fixes configuration by specifying the active job queue adapter under config/application.rb