### PR TITLE
Changes Receipt Bank to Dext

### DIFF
--- a/app/views/transactions/success.html.slim
+++ b/app/views/transactions/success.html.slim
@@ -1,13 +1,13 @@
 .ui.container.padded.text.segment.categorize-container
     .ui.header.center.aligned
       | We got it, thanks! 😻
-    p 
-      | Next is to 
-      strong upload your invoice or receipt to Receipt Bank.
+    p
+      | Next is to
+      strong upload your invoice or receipt to Dext.
     p
       strong On mobile?
-      |  Open the Receipt Bank app. Or you can open the web application by clicking this button:
-    a.ui.primary.button[href="https://app.receipt-bank.com/add_items/costs/upload" rel="noopener noreferrer" target="_blank"]
-      | Upload invoice to Receipt Bank
+      |  Open the Dext app. Or you can open the web application by clicking this button:
+    a.ui.primary.button[href="https://app.dext.com/gamma/costs/inbox" rel="noopener noreferrer" target="_blank"]
+      | Upload invoice to Dext
     .gif-container
       = image_tag "success.gif", class:"gif"


### PR DESCRIPTION
Why: Receipt Bank changed it's name

What: Changes upload path to Dext, but can't directly link to the uploader